### PR TITLE
ci: include additional dlls for windows builds

### DIFF
--- a/.github/workflows/libzedmd.yml
+++ b/.github/workflows/libzedmd.yml
@@ -49,7 +49,7 @@ jobs:
           - { os: windows-2025-vs2026, platform: win, arch: x64, type: Release }
           - { os: windows-2025-vs2026, platform: win, arch: x64, type: Debug }
           - { os: windows-2025-vs2026, platform: win, arch: x86, type: Release }
-          - { os: windows-2025, platform: win-mingw, arch: x64, type: Release }
+          - { os: windows-2025-vs2026, platform: win-mingw, arch: x64, type: Release }
           - { os: macos-15, platform: macos, arch: arm64, type: Release }
           - { os: macos-15, platform: macos, arch: x64, type: Release }
           - { os: ubuntu-24.04, platform: linux, arch: x64, type: Release }
@@ -193,11 +193,11 @@ jobs:
           mkdir tmp
           if [[ "${{ matrix.arch }}" == "x64" ]]; then
             cp build/${{ matrix.type }}/*64.lib tmp
-            cp build/${{ matrix.type }}/*64.dll tmp
           else
             cp build/${{ matrix.type }}/*.lib tmp
-            cp build/${{ matrix.type }}/*.dll tmp
           fi
+          cp build/${{ matrix.type }}/*.dll tmp
+          cp build/*.dll tmp
           cp build/${{ matrix.type }}/zedmd-client-portable.exe tmp
           cp build/${{ matrix.type }}/zedmd-client.exe tmp
           cp build/${{ matrix.type }}/zedmd-test-portable.exe tmp
@@ -320,7 +320,7 @@ jobs:
           path: release
           skip-decompress: true
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true


### PR DESCRIPTION
Dependant dlls were not copied in artifacts, so zedmd test executables wouldn't launch.